### PR TITLE
RFC: TrackedBitVector for honest DMD of non-numpy computation

### DIFF
--- a/docs/rfc-tracked-bitvector.md
+++ b/docs/rfc-tracked-bitvector.md
@@ -1,0 +1,134 @@
+# RFC: TrackedBitVector for honest DMD measurement
+
+## Problem
+
+TrackedArray measures data movement for numpy operations, but submissions
+can "escape" tracking by converting to plain Python types:
+
+```python
+x_block = np.asarray(x[:rows])  # strips TrackedArray wrapper
+mask = 0
+for j in range(n_bits):
+    if x_block[i][j] > 0:       # reads happen but aren't tracked
+        mask |= 1 << j          # Python int ops — invisible to tracker
+```
+
+After `np.asarray()`, all subsequent operations (bitwise XOR, comparisons,
+shifts) happen on untracked Python integers. The DMD metric undercounts
+because it only sees the initial numpy read, not the algorithmic work.
+
+### Impact on current leaderboard
+
+We measured the #1 submission (passive_gf2_rref_minimal_22rows by Hydral8)
+which uses exactly this pattern — GF(2) elimination on Python ints:
+
+| Measurement | DMC |
+|------------|-----|
+| Current (untracked elimination) | 45,904 |
+| With TrackedBitVector (fully tracked) | 81,106 |
+| Numpy GF2 same algorithm, n+1 samples | 1,631,797 |
+
+The escape hatch undercounts DMC by ~1.6x for this submission. The numpy
+version of the same algorithm reports 20x higher DMC — most of that gap is
+real (bit-packing genuinely moves less data), but some is from untracked
+operations.
+
+## Proposal: TrackedBitVector
+
+A Python int wrapper that records reads and writes on the same LRU stack
+used by TrackedArray, measured in **bits** rather than floats:
+
+```python
+from sparse_parity.tracked_bitvector import TrackedBitVector, pack_row
+
+tracker = LRUStackTracker()
+# Pack numpy row into tracked bit vector
+mask = pack_row(x[i], n_bits, "mask_0", tracker)
+
+# All operations are tracked
+mask_a ^= mask_b   # reads both (n_bits each), writes result
+bit = mask_a[col]  # reads 1 bit
+mask_a.swap_with(mask_b)  # reads both, writes both
+```
+
+### What's tracked
+
+| Operation | Reads | Writes |
+|-----------|-------|--------|
+| `a ^ b` | a (n_bits), b (n_bits) | result (n_bits) |
+| `a ^= b` | a (n_bits), b (n_bits) | a (n_bits) |
+| `a[i]` | a (1 bit) | — |
+| `a.swap_with(b)` | a (n_bits), b (n_bits) | a (n_bits), b (n_bits) |
+| `bool(a)` | a (n_bits) | — |
+| `int(a)` | a (n_bits) | — |
+
+### Shared LRU stack
+
+TrackedBitVector writes/reads go through the same `LRUStackTracker` as
+TrackedArray. Bit-level and float-level accesses compete for stack positions
+realistically: if you read a large numpy array between two reads of a
+bitvector, the bitvector sinks deeper in the stack and costs more.
+
+## Design tradeoffs
+
+### Option A: Automatic wrapping (harness does it)
+
+The evaluation harness could automatically wrap any Python ints derived
+from numpy data. This is hard to implement — you'd need to intercept
+`int()`, `float()`, `.item()`, and implicit scalar conversion. Python
+doesn't provide hooks for integer arithmetic.
+
+**Pros**: Zero burden on submitters. Honest measurement.
+**Cons**: Extremely difficult to implement fully. Python ints are
+fundamental types — there's no `__int_ufunc__` protocol.
+
+### Option B: Require tracked types (coding standard)
+
+Submissions that do non-numpy computation must use TrackedBitVector
+(or a similar tracked type) for all data-bearing operations. The
+harness provides TrackedBitVector alongside TrackedArray.
+
+**Pros**: Feasible to implement. Honest measurement. Rewards genuine
+algorithmic efficiency.
+**Cons**: Burden on submitters. Can't enforce automatically — a
+submission could still use plain ints and get undercounted. Requires
+human review to verify compliance.
+
+### Option C: Ban non-numpy computation (restrict the design space)
+
+Require all computation to go through numpy operations. Disqualify
+submissions that extract data to Python loops.
+
+**Pros**: Simple to enforce. TrackedArray covers everything.
+**Cons**: Disqualifies legitimate optimizations. Bit-packing IS more
+cache-efficient — banning it penalizes good algorithms.
+
+### Option D: Accept the limitation (document it)
+
+Keep TrackedArray as-is. Document that the metric measures numpy-level
+data movement. Accept that bit-packed implementations get lower scores
+because they genuinely use less numpy-level bandwidth.
+
+**Pros**: No code changes. Simple.
+**Cons**: The metric doesn't measure what it claims to (total data
+movement). Rankings may not reflect true energy cost.
+
+## Recommendation
+
+**Option B** with a documentation/tooling assist. Provide TrackedBitVector
+in the challenge repo. Add a note in the rules that submissions doing
+non-numpy computation should use TrackedBitVector for honest scoring.
+The harness can warn (but not block) if it detects `np.asarray()` calls
+in submission code.
+
+This preserves the advantage of bit-packed algorithms (they genuinely
+move less data per operation) while ensuring the measurement is honest.
+The ~1.6x correction for Hydral8's submission shows the escape isn't
+catastrophic — the bit-packed approach is still legitimately better than
+numpy GF2, just not by as much as the uncorrected score suggests.
+
+## Files in this PR
+
+- `src/sparse_parity/tracked_bitvector.py` — TrackedBitVector implementation
+- `tests/test_tracked_bitvector.py` — 16 tests (ops, DMD, integration)
+- `docs/rfc-tracked-bitvector.md` — this document

--- a/src/sparse_parity/tracked_bitvector.py
+++ b/src/sparse_parity/tracked_bitvector.py
@@ -1,0 +1,200 @@
+"""Tracked bit-packed integer for DMD measurement of non-numpy computation.
+
+TrackedBitVector wraps a Python int representing a packed bit vector.
+Every operation (XOR, AND, OR, comparison, bit extraction) records
+reads and writes on the same LRU stack used by TrackedArray, measured
+in bits rather than floats.
+
+This closes the "escape to Python ints" loophole in TrackedArray:
+algorithms that pack numpy data into Python integers for bitwise
+computation can use TrackedBitVector to ensure all data movement
+is accounted for.
+
+Usage:
+    from sparse_parity.tracked_bitvector import TrackedBitVector
+    from sparse_parity.lru_tracker import LRUStackTracker
+
+    tracker = LRUStackTracker()
+    a = TrackedBitVector(0b1101, 4, "a", tracker)
+    b = TrackedBitVector(0b1010, 4, "b", tracker)
+    c = a ^ b   # reads a (4 bits), reads b (4 bits), writes c (4 bits)
+    bit = a[2]  # reads 1 bit from a
+"""
+
+import math
+
+_next_id = 0
+
+
+def _auto_name(prefix="bv"):
+    global _next_id
+    _next_id += 1
+    return f"_{prefix}_{_next_id}"
+
+
+def reset_counter():
+    global _next_id
+    _next_id = 0
+
+
+class TrackedBitVector:
+    """A Python int with DMD tracking, measured in bits.
+
+    Every read/write goes through the same LRUStackTracker used by
+    TrackedArray, so bit-level and float-level operations share the
+    same LRU stack and compete for stack positions realistically.
+    """
+
+    __slots__ = ('value', 'n_bits', 'name', 'tracker')
+
+    def __init__(self, value, n_bits, name=None, tracker=None):
+        self.value = int(value)
+        self.n_bits = n_bits
+        self.name = name or _auto_name()
+        self.tracker = tracker
+        if tracker is not None:
+            tracker.write(self.name, n_bits)
+
+    def _read(self, size=None):
+        if self.tracker is not None:
+            self.tracker.read(self.name, size or self.n_bits)
+
+    def _make_result(self, value, prefix="bv"):
+        name = _auto_name(prefix)
+        result = TrackedBitVector.__new__(TrackedBitVector)
+        result.value = int(value)
+        result.n_bits = self.n_bits
+        result.name = name
+        result.tracker = self.tracker
+        if self.tracker is not None:
+            self.tracker.write(name, self.n_bits)
+        return result
+
+    # --- Bitwise operations ---
+
+    def __xor__(self, other):
+        self._read()
+        if isinstance(other, TrackedBitVector):
+            other._read()
+            return self._make_result(self.value ^ other.value, "xor")
+        return self._make_result(self.value ^ int(other), "xor")
+
+    def __ixor__(self, other):
+        # In-place XOR: read self + other, write back to self
+        self._read()
+        if isinstance(other, TrackedBitVector):
+            other._read()
+            self.value ^= other.value
+        else:
+            self.value ^= int(other)
+        if self.tracker is not None:
+            self.tracker.write(self.name, self.n_bits)
+        return self
+
+    def __and__(self, other):
+        self._read()
+        if isinstance(other, TrackedBitVector):
+            other._read()
+            return self._make_result(self.value & other.value, "and")
+        return self._make_result(self.value & int(other), "and")
+
+    def __or__(self, other):
+        self._read()
+        if isinstance(other, TrackedBitVector):
+            other._read()
+            return self._make_result(self.value | other.value, "or")
+        return self._make_result(self.value | int(other), "or")
+
+    def __invert__(self):
+        self._read()
+        mask = (1 << self.n_bits) - 1
+        return self._make_result(self.value ^ mask, "not")
+
+    def __lshift__(self, n):
+        self._read()
+        return self._make_result(self.value << n, "lsh")
+
+    def __rshift__(self, n):
+        self._read()
+        return self._make_result(self.value >> n, "rsh")
+
+    # --- Bit extraction ---
+
+    def __getitem__(self, bit_idx):
+        """Extract a single bit. Costs 1 bit read."""
+        if self.tracker is not None:
+            self.tracker.read(self.name, 1)
+        return (self.value >> bit_idx) & 1
+
+    # --- Comparison ---
+
+    def __eq__(self, other):
+        self._read()
+        if isinstance(other, TrackedBitVector):
+            other._read()
+            return self.value == other.value
+        return self.value == int(other)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __bool__(self):
+        """bool(bv) — reads the vector to test if nonzero."""
+        self._read()
+        return bool(self.value)
+
+    # --- Reverse operations (when int is on the left) ---
+
+    def __rxor__(self, other):
+        self._read()
+        return self._make_result(int(other) ^ self.value, "xor")
+
+    def __rand__(self, other):
+        self._read()
+        return self._make_result(int(other) & self.value, "and")
+
+    def __ror__(self, other):
+        self._read()
+        return self._make_result(int(other) | self.value, "or")
+
+    # --- Conversion ---
+
+    def __int__(self):
+        self._read()
+        return self.value
+
+    def __index__(self):
+        """Allows use in slicing and bin(). Records a read."""
+        self._read()
+        return self.value
+
+    def __repr__(self):
+        return f"TrackedBitVector({self.value:#0{self.n_bits+2}b}, {self.n_bits} bits, {self.name!r})"
+
+    # --- Swap support (for row swaps in elimination) ---
+
+    def swap_with(self, other):
+        """Swap values with another TrackedBitVector. Reads both, writes both."""
+        self._read()
+        other._read()
+        self.value, other.value = other.value, self.value
+        if self.tracker is not None:
+            self.tracker.write(self.name, self.n_bits)
+        if other.tracker is not None:
+            other.tracker.write(other.name, other.n_bits)
+
+
+def pack_row(array_row, n_bits, name=None, tracker=None):
+    """Pack a numpy row of {-1, +1} or {0, 1} values into a TrackedBitVector.
+
+    If the input is a TrackedArray, a read is recorded (via normal indexing).
+    The resulting TrackedBitVector records a write.
+    """
+    mask = 0
+    for j in range(n_bits):
+        val = array_row[j]  # triggers TrackedArray read if applicable
+        if hasattr(val, 'item'):
+            val = val.item()
+        if val > 0:
+            mask |= 1 << j
+    return TrackedBitVector(mask, n_bits, name, tracker)

--- a/tests/test_tracked_bitvector.py
+++ b/tests/test_tracked_bitvector.py
@@ -1,0 +1,208 @@
+"""Tests for TrackedBitVector — bit-level DMD tracking."""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+import math
+import numpy as np
+from sparse_parity.lru_tracker import LRUStackTracker
+from sparse_parity.tracked_bitvector import TrackedBitVector, pack_row, reset_counter
+
+
+def setup_function():
+    reset_counter()
+
+
+# =============================================================================
+# Basic operations
+# =============================================================================
+
+class TestBitVectorOps:
+    def test_xor(self):
+        t = LRUStackTracker()
+        a = TrackedBitVector(0b1100, 4, "a", t)
+        b = TrackedBitVector(0b1010, 4, "b", t)
+        c = a ^ b
+        assert c.value == 0b0110
+        assert t.summary()["reads"] == 2  # read a, read b
+
+    def test_ixor(self):
+        t = LRUStackTracker()
+        a = TrackedBitVector(0b1100, 4, "a", t)
+        b = TrackedBitVector(0b1010, 4, "b", t)
+        a ^= b
+        assert a.value == 0b0110
+        assert a.name == "a"  # in-place, same name
+        assert t.summary()["reads"] == 2
+
+    def test_and(self):
+        t = LRUStackTracker()
+        a = TrackedBitVector(0b1100, 4, "a", t)
+        b = TrackedBitVector(0b1010, 4, "b", t)
+        c = a & b
+        assert c.value == 0b1000
+
+    def test_or(self):
+        t = LRUStackTracker()
+        a = TrackedBitVector(0b1100, 4, "a", t)
+        b = TrackedBitVector(0b1010, 4, "b", t)
+        c = a | b
+        assert c.value == 0b1110
+
+    def test_invert(self):
+        t = LRUStackTracker()
+        a = TrackedBitVector(0b1100, 4, "a", t)
+        b = ~a
+        assert b.value == 0b0011
+
+    def test_shift(self):
+        t = LRUStackTracker()
+        a = TrackedBitVector(0b1100, 4, "a", t)
+        assert (a >> 2).value == 0b0011
+        assert (a << 1).value == 0b11000
+
+    def test_getitem(self):
+        t = LRUStackTracker()
+        a = TrackedBitVector(0b1010, 4, "a", t)
+        assert a[0] == 0
+        assert a[1] == 1
+        assert a[3] == 1
+        # Each bit extraction is 1 bit read
+        assert t.summary()["reads"] == 3
+
+    def test_eq(self):
+        t = LRUStackTracker()
+        a = TrackedBitVector(5, 4, "a", t)
+        b = TrackedBitVector(5, 4, "b", t)
+        assert a == b
+        assert not (a != b)
+
+    def test_bool(self):
+        t = LRUStackTracker()
+        a = TrackedBitVector(0, 4, "a", t)
+        b = TrackedBitVector(1, 4, "b", t)
+        assert not a
+        assert b
+
+    def test_swap(self):
+        t = LRUStackTracker()
+        a = TrackedBitVector(0b1100, 4, "a", t)
+        b = TrackedBitVector(0b0011, 4, "b", t)
+        a.swap_with(b)
+        assert a.value == 0b0011
+        assert b.value == 0b1100
+        # Swap reads both, writes both
+        assert t.summary()["reads"] == 2
+
+
+# =============================================================================
+# DMD accounting
+# =============================================================================
+
+class TestBitVectorDMD:
+    def test_writes_are_free(self):
+        t = LRUStackTracker()
+        TrackedBitVector(0b1111, 4, "a", t)
+        TrackedBitVector(0b0000, 4, "b", t)
+        assert t.summary()["dmd"] == 0.0  # writes only, no cost
+
+    def test_xor_dmd(self):
+        t = LRUStackTracker()
+        a = TrackedBitVector(0b1100, 4, "a", t)
+        b = TrackedBitVector(0b1010, 4, "b", t)
+        c = a ^ b
+        # Per-element LRU stack: each bit is a separate entry.
+        # After writing a(4 bits) then b(4 bits), stack has 8 entries.
+        # Reading a then b incurs nonzero DMD from stack distances.
+        dmd = t.summary()["dmd"]
+        assert dmd > 0, "XOR should have nonzero DMD from reading inputs"
+        assert t.summary()["reads"] == 2  # two read() calls (a and b)
+
+    def test_shared_stack_with_lru(self):
+        """TrackedBitVector and LRUStackTracker share the same stack."""
+        t = LRUStackTracker()
+        a = TrackedBitVector(0b11, 2, "a", t)
+        t.write("big_buffer", 100)  # push 100 elements onto stack
+        a._read()  # a is now deep in the stack
+        # a's distance should reflect the 100 elements pushed after it
+        dmd = t.summary()["dmd"]
+        assert dmd > 2 * math.sqrt(100)  # at least sqrt(100) per bit
+
+
+# =============================================================================
+# Integration with numpy
+# =============================================================================
+
+class TestPackRow:
+    def test_pack_basic(self):
+        t = LRUStackTracker()
+        row = np.array([1.0, -1.0, 1.0, -1.0])
+        bv = pack_row(row, 4, "packed", t)
+        assert bv.value == 0b0101  # bits 0 and 2 are +1
+
+    def test_pack_gf2(self):
+        t = LRUStackTracker()
+        row = np.array([0, 1, 1, 0], dtype=np.uint8)
+        bv = pack_row(row, 4, "packed", t)
+        assert bv.value == 0b0110
+
+
+# =============================================================================
+# GF(2) elimination end-to-end
+# =============================================================================
+
+class TestGF2WithBitVector:
+    def test_solves_parity(self):
+        """Full GF(2) solve using TrackedBitVector."""
+        rng = np.random.RandomState(42)
+        n, k = 20, 3
+        secret = sorted(rng.choice(n, k, replace=False).tolist())
+        x = rng.choice([-1.0, 1.0], size=(22, n))
+        y = np.prod(x[:, secret], axis=1)
+
+        t = LRUStackTracker()
+        target_flip = 1 if (k % 2 == 0) else 0
+
+        masks = []
+        rhs_list = []
+        for i in range(22):
+            bv = pack_row(((x[i] + 1) / 2).astype(np.uint8), n, f"m{i}", t)
+            masks.append(bv)
+            yval = (1 if y[i] > 0 else 0) ^ target_flip
+            rhs_list.append(TrackedBitVector(yval, 1, f"r{i}", t))
+
+        pivot_row = 0
+        pivot_cols = []
+        for col in range(n):
+            found = pivot_row
+            while found < 22:
+                if masks[found][col]:
+                    break
+                found += 1
+            if found == 22:
+                continue
+            if found != pivot_row:
+                masks[pivot_row].swap_with(masks[found])
+                rhs_list[pivot_row].swap_with(rhs_list[found])
+            for row in range(pivot_row + 1, 22):
+                if masks[row][col]:
+                    masks[row] ^= masks[pivot_row]
+                    rhs_list[row] ^= rhs_list[pivot_row]
+            pivot_cols.append(col)
+            pivot_row += 1
+
+        solution = [0] * n
+        for idx in range(pivot_row - 1, -1, -1):
+            col = pivot_cols[idx]
+            val = int(rhs_list[idx])
+            for c2 in range(col + 1, n):
+                if masks[idx][c2] and solution[c2]:
+                    val ^= 1
+            solution[col] = val
+
+        found_secret = sorted([i for i in range(n) if solution[i]])
+        assert found_secret == secret, f"Expected {secret}, got {found_secret}"
+
+        # DMD should be nonzero (elimination did real work)
+        assert t.summary()["dmd"] > 0


### PR DESCRIPTION
## Problem

Submissions can escape TrackedArray via `np.asarray()` and do computation on untracked Python ints. The #1 leaderboard entry does this — GF(2) elimination on bit-packed integers, invisible to the tracker.

## Proposal

`TrackedBitVector` wraps Python integers so bitwise ops (XOR, AND, shifts, bit extraction) record reads/writes on the same LRU stack as TrackedArray, measured in **bits**.

### Impact on current #1

| Measurement | DMC |
|------------|-----|
| Current (untracked elimination) | 45,904 |
| **With TrackedBitVector** | **81,106** |
| Numpy GF2 same algorithm | 1,631,797 |

The escape undercounts by ~1.6x. The bit-packed approach is still legitimately 20x better than numpy — it genuinely moves less data. TrackedBitVector makes the measurement honest while preserving that advantage.

## What's included

- `src/sparse_parity/tracked_bitvector.py` — implementation (TrackedBitVector, pack_row helper)
- `tests/test_tracked_bitvector.py` — 16 tests
- `docs/rfc-tracked-bitvector.md` — RFC discussing 4 design options and recommending Option B (provide the tool, document the expectation, don't hard-enforce)

## Discussion wanted

This is a proposal, not a final decision. Key questions:
1. Should submissions be **required** to use TrackedBitVector for non-numpy ops, or just encouraged?
2. Should the harness **warn** when it detects `np.asarray()` in submission code?
3. Is the 1.6x correction significant enough to matter, or should we accept the limitation?

🤖 Generated with [Claude Code](https://claude.com/claude-code)